### PR TITLE
[Tests] Added method to easily pull in data, #72

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Testing
+tests/helper/data/*.geojson

--- a/tests/helper/client.py
+++ b/tests/helper/client.py
@@ -1,0 +1,149 @@
+# Copyright (c) Facebook, Inc. and its affiliates. (http://www.facebook.com)
+# -*- coding: utf-8 -*-
+
+"""
+tests.helper.client
+~~~~~~~~~~~~~~~~~~~
+
+For pulling in data for test purposes from the Mapillary APIv4. Some higher level requirements
+use a geojson or a bbox as the query extent for further testing. This file serves to be an
+easy way of pulling in data from endpoints through an easy CLI instead of writing Python
+code as 1 offs for getting the data and parsing it.
+
+Contributions welcome!
+
+:copyright: (c) 2021 Facebook
+:license: MIT LICENSE
+"""
+
+# Local imports
+import fetch
+
+# Package imports
+import inspect
+import logging
+import json
+import sys
+import os
+
+colors = {
+    "HEADER": "\033[95m",
+    "OKBLUE": "\033[94m",
+    "OKCYAN": "\033[96m",
+    "OKGREEN": "\033[92m",
+    "WARNING": "\033[93m",
+    "FAIL": "\033[91m",
+    "ENDC": "\033[0m",
+    "BOLD": "\033[1m",
+    "UNDERLINE": "\033[4m",
+}
+
+def list_fetched_functions(fetched_functions: list) -> None:
+    """Simply lists out the functions described in fetch.py along with their DocString
+    
+    :param fetched_functions: List of function names along with their references in a tuple set
+    :type fetched_functions: list
+
+    :return: Nothing to return
+    :rtype: None
+    """
+
+    # Through each tuple in the format (name, reference)
+    for index, function in enumerate(fetched_functions):
+
+        # Print out ... 
+        print(
+
+            # ... an index for the function, then the name of the function in cyan color ...
+            f"{index + 1}. {colors['OKCYAN']}{function[0]}{colors['ENDC']} "
+
+            # ... then print the docstring as well
+            f"- {function[1].__doc__}"
+        )
+
+def save_as_geojson(data: dict) -> None:
+    """Saves the resulting geojson dictionary in a file tagged .geojson
+
+    :param data: The data to save
+    :type data: dict
+
+    :return: Nothing to return
+    :rtype: None
+    """
+
+    # TODO: Test if this works perfectly fine in Windows, since it uses the `os` package
+
+    # Save the file at the given path, create it if it does not exist
+    with open(f'{os.path.abspath(".")}/data/{sys.argv[2]}.geojson', mode='w') as geojson_file:
+        
+        # Save the dictionary as a json in a clean formatted way
+        json.dump(data, geojson_file, sort_keys=True, indent=4)
+
+def main():
+    """Main logic for the CLI"""
+
+    # Getting the list of functions and their references from fetch.py
+    fetched_functions = inspect.getmembers(fetch, inspect.isfunction)
+
+    # If there are insufficient arguments
+    if len(sys.argv) < 3:
+
+        # Log an error ... 
+        logging.error(
+
+            # ... indicating the source of the error ...
+            " - client.py\n"
+
+            # ... the reason for the error ...
+            f"{colors['FAIL']}Invalid format!{colors['ENDC']}\n"
+
+            # ... giving the user a format for the colors ...
+            f"Try: python client.py {colors['BOLD']}'MLY|XXX'{colors['ENDC']} "
+
+            # ... format of the function called
+            f"{colors['OKCYAN']}fetch_function_here{colors['ENDC']}\n"
+        )
+
+        # Finally, list the functions for the user
+        list_fetched_functions(fetched_functions=fetched_functions)
+
+    else:
+
+        # Getting the access token
+        access_token = str(sys.argv[1])
+
+        # result output variable
+        result: dict = {}
+
+        # Going through each tuple of the format (func_name, func_reference)
+        for function in fetched_functions:
+
+            # If the function named is what is asked through the args
+            if function[0] == str(sys.argv[2]):
+
+                # Get the resulting output from the reference
+                result = function[1](access_token=access_token)
+
+        # If the results ends up empty
+        if result == {}:
+
+            # Log an error ... 
+            logging.error(
+
+                # ... indicating the source of the error ...                
+                " - client.py\n"
+
+            # ... the reason for the error                
+                f"{colors['FAIL']}Unrecognized function call!{colors['ENDC']}\n"
+            )
+
+            # Finally, list the functions for the user
+            list_fetched_functions(fetched_functions=fetched_functions)
+
+        # Saving the data
+        # TODO: Assumes user is working in Linux!
+        save_as_geojson(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/helper/data/.gitkeep
+++ b/tests/helper/data/.gitkeep
@@ -1,0 +1,1 @@
+Fetch data from client.py will be stored here

--- a/tests/helper/fetch.py
+++ b/tests/helper/fetch.py
@@ -1,0 +1,78 @@
+# Copyright (c) Facebook, Inc. and its affiliates. (http://www.facebook.com)
+# -*- coding: utf-8 -*-
+
+"""
+tests.helper.fetch
+~~~~~~~~~~~~~~~~~~
+
+This file contains the set of functions that are called by the client.py
+in response to a query.
+
+Contributions welcome!
+
+:copyright: (c) 2021 Facebook
+:license: MIT LICENSE
+"""
+
+# Package imports
+import mercantile, requests
+import vt2geojson.tools
+
+
+def fetch_map_feature_point(access_token: str):
+    """For fetching utility poles and street lights within a bounding using the Mercantile/Mapbox
+    Vector Tile library
+
+    Reference::
+        1. 'https://blog.mapillary.com/update/2021/06/23/getting-started-with-the-new-mapillary-api-v4.html'
+    """
+
+    # define an empty geojson as output
+    output = {"type": "FeatureCollection", "features": []}
+
+    # a bounding box in [east_lng,_south_lat,west_lng,north_lat] format
+    east, south, west, north = [
+        -80.13423442840576,
+        25.77376933762778,
+        -80.1264238357544,
+        25.788608487732198,
+    ]
+
+    filter_values = ["object--support--utility-pole", "object--street-light"]
+    # get the tiles with x and y coors intersecting bbox at zoom 14 only
+    tiles = list(mercantile.tiles(east, south, west, north, 14))
+
+    # loop through all tiles to get IDs of Mapillary data
+    for tile in tiles:
+
+        # Creating the tile URL
+        tile_url = (
+            f"https://tiles.mapillary.com/maps/vtp/mly_map_feature_point/2/"
+            f"{tile.z}/{tile.x}/{tile.y}?access_token={access_token}"
+        )
+
+        response = requests.get(tile_url)
+
+        data = vt2geojson.tools.vt_bytes_to_geojson(
+            response.content, tile.x, tile.y, tile.z
+        )
+
+        filtered_data = [
+            feature
+            for feature in data["features"]
+            if feature["properties"]["value"] in filter_values
+        ]
+
+        for feature in filtered_data:
+
+            if (
+                feature["geometry"]["coordinates"][0] > east
+                and feature["geometry"]["coordinates"][0] < west
+            ) and (
+                feature["geometry"]["coordinates"][1] > south
+                and feature["geometry"]["coordinates"][1] < north
+            ):
+
+                output["features"].append(feature)
+
+    return output


### PR DESCRIPTION
A nice to have and an enhancement (:trophy:), this PR works to close #72 and solve it by introducing a simple method of fetching data from the API without remembering the different defaults or going through the whole SDK just to retrieve a `geojson`. 

You can test it by going into `tests/helper/`, and then running `python client.py`.

As an example, please see the below screenshot,

![image](https://user-images.githubusercontent.com/41635766/127748339-e0448361-3dc1-42a4-b780-accece26e9a5.png)

The above output is for guiding the user on how to use the written CLI program

Running the command `python client.py 'MLY|XXX' fetch_map_feature_point`, a pretty printed `.geojson` appears under `data/`,

![image](https://user-images.githubusercontent.com/41635766/127748386-c99576a8-9de5-4e43-b8ff-b439add94cfd.png)

Future contributors can now create examples they found or like by adding functions in `fetch.py` that has all the different functions listed out.

Signed-off-by: Saif Ul Islam <saifulislam84210@gmail.com>